### PR TITLE
Add example: draw card at end phase

### DIFF
--- a/appendix/end-phase-draw.md
+++ b/appendix/end-phase-draw.md
@@ -1,0 +1,13 @@
+# 附录D：结束阶段摸牌技能示例
+
+一个最基础的触发技，在你的回合结束阶段触发，你可以选择摸一张牌。
+
+```javascript
+"ex_end_draw": {
+    trigger: { player: "phaseEnd" },
+    prompt: "你可以摸一张牌",
+    async content(event, trigger, player){
+        await player.draw();
+    }
+} // 结束阶段，你可以摸一张牌
+```


### PR DESCRIPTION
## Summary
- add `end-phase-draw.md` in appendix with a basic triggered skill example

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68453a1c7fe88325a7abc9d3b3ed6a0b